### PR TITLE
Remove style.css import, pass config via prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - [wc-test-app-react](#wc-test-app-react)
   - [Next Steps](#next-steps)
   - [Changes 2023.02.06](#changes-20230206)
+  - [Changes 2023.02.07](#changes-20230207)
 
 This repo is to try and figure out how to get the crate builder built as a fully functioning web
 component. It is based on the pull request created by @beepsoft @
@@ -120,3 +121,11 @@ In [index.wc.js](src%2Fcrate-builder%2Findex.wc.js) I added the compiled `style.
 My current solution for passing objects and functions to the web component is to do it via [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis), see [Shell.component.wc.vue](src%2Fcrate-builder%2FShell.component.wc.vue). Users of the web component should pass the name of the function/object as it is set on globalThis (and the users should take care of avoiding name clashes). See [App.tsx](wc-test-app-react%2Fsrc%2FApp.tsx).
 
 From now on translation of web component properties can happen in [Shell.component.wc.vue](src%2Fcrate-builder%2FShell.component.wc.vue) and then passed to [Shell.component.vue](src%2Fcrate-builder%2FShell.component.vue) in the expected format.
+
+# Changes 2023.02.07
+
+1. Removed import of `style.css` in react [App.tsx](wc-test-app-react%2Fsrc%2FApp.tsx) as it is not required.
+
+3. Instead of accessing `globalThis.DescriboCrateBuilderConfiguration` in [Shell.component.wc.vue](src%2Fcrate-builder%2FShell.component.wc.vue) I suggest to pass the name of the config object on `globalThis` via the `config` prop. This way we could theoretically have multiple components on screen with different configs, and it is the responsibility of the caller to avoid name clashes.
+
+4. The React side is now reactive: when you press the "Change crate" button the value of the crate field changes in `globalThis[props.config]`. However, this change is not picked up in [Shell.component.wc.vue](src%2Fcrate-builder%2FShell.component.wc.vue). Can you please take a look at this? 

--- a/src/crate-builder/Shell.component.wc.vue
+++ b/src/crate-builder/Shell.component.wc.vue
@@ -21,22 +21,6 @@
         <div class="flex flex-col bg-yellow-200 p-10 mt-10">
             Function and object values passed from react:
             <ul class="list-disc">
-                <!-- Cannot use globalThis here ... -->
-                <!-- <li>
-                    props.someglobalobject: <b>{{ props.someglobalobject }}</b>
-                </li>
-                <li>
-                    props.someglobalobject value: <b>{{ someglobalobjectValue }}</b>
-                </li>
-                <li>
-                    props.someglobalobject.nameAndAge(): <b>{{ nameAndAge }}</b>
-                </li>
-                <li>
-                    props.someglobalfunction: <b>{{ props.someglobalfunction }}</b>
-                </li>
-                <li>
-                    props.someglobalfunction value: <b>{{ someglobalfunctionValue }}</b>
-                </li> -->
                 <li>{{ crate }}</li>
                 <li>{{ profile }}</li>
                 <li>{{ lookup }}</li>
@@ -46,11 +30,24 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import {computed, reactive, watch} from "vue";
 import DescriboCrateBuilder from "./Shell.component.vue";
 
+
 // get the configuration from globalThis and set it inside this component
-const $this = globalThis.DescriboCrateBuilderConfiguration;
+// const $this = globalThis.DescriboCrateBuilderConfiguration;
+//
+// @marcolarosa: I suggest passing the name of the config via a prop. This way we could theoretically have multiple components on
+//  screen with different configs, and it is the responsibility of the caller to avoid name clashes.
+//
+//  Another issue: I don't know if $this is reactive here or not. The React test app now updates the contents of
+//  globalThis[props.config] when the "Change crate" button is clicked, but the vue side doesn't change.
+//
+const props = defineProps({
+    config: String
+});
+
+const $this = globalThis[props.config];
 let crate = computed(() => $this.crate);
 let profile = computed(() => $this.profile);
 let lookup = computed(() => $this.lookup);
@@ -59,27 +56,4 @@ let enableCratePreview = computed(() => $this?.config?.enableCratePreview ?? tru
 let enableBrowseEntities = computed(() => $this?.config?.enableBrowseEntities ?? true);
 let enableTemplateSave = computed(() => $this?.config?.enableTemplateSave ?? false);
 let readonly = computed(() => $this?.config?.readonly ?? false);
-
-// const props = defineProps({
-//     crate: {
-//         type: [String, undefined],
-//     },
-//     profile: {
-//         type: [String, undefined],
-//     },
-
-//     someglobalfunction: {
-//         type: [String, undefined],
-//     },
-//     someglobalobject: {
-//         type: [String, undefined],
-//     },
-// })
-
-// console.log("Shell.component.wc.vue -- props", props)
-
-// // Callback functions and non-record objects with methods can passed via globalThis
-// const someglobalobjectValue = globalThis[props.someglobalobject]
-// const someglobalfunctionValue = globalThis[props.someglobalfunction]("called from web component")
-// const nameAndAge = globalThis[props.someglobalobject].nameAndAge()
 </script>

--- a/src/crate-builder/index.wc.js
+++ b/src/crate-builder/index.wc.js
@@ -15,6 +15,9 @@ config.autoReplaceSvg = "nest";
 //   better to not do it here so that the user of the component can decide when they want the
 //   style to be loaded)
 
+// @marcolarosa: I just forgot to remove from App.tsx. The css must be embedded into the web component like below
+// otherise it would not have effect.
+
 // The trick is to import from the vue build, because it is built before this, so style.css is already available.
 // If we tried to import from dist/web-component/style.css it was not available since we are in the building process
 // and so style.css wouldbe only available at the end of it.

--- a/vite.wc.config.js
+++ b/vite.wc.config.js
@@ -14,6 +14,9 @@ export default defineConfig({
             name: "DescriboCrateBuilderWC",
             fileName: "describo-crate-builder-wc",
         },
+        // Don't minify so there's a chance to debug problems while experimenting
+        minify: false,
+        minifySyntax: false
     },
     plugins: [vue()],
     // plugins: [vue({ customElement: true})],

--- a/wc-test-app-react/src/App.tsx
+++ b/wc-test-app-react/src/App.tsx
@@ -2,7 +2,6 @@
 import metaData from "./data/ro-crate-metadata.json"
 // Use the version built in the parent.
 import "crate-builder-wc/dist/web-component/describo-crate-builder-wc.umd"
-import "crate-builder-wc/dist/web-component/style.css"
 
 import {useState, useEffect, useRef, useLayoutEffect, DOMAttributes} from "react";
 
@@ -19,6 +18,18 @@ declare global {
 function DescriboCrateBuilder({crate, profile, onDataChange}: any) {
   const ref = useRef();
 
+  // Initial setting of globalThis.DescriboCrateBuilderConfiguration
+  const [describoConfig, setDescriboConfig] = useState<any>(() =>{
+    const data = {
+      crate,
+      profile,
+      lookup: {},
+    }
+    // @ts-ignore
+    globalThis.DescriboCrateBuilderConfiguration = data
+    return data
+  })
+
   useLayoutEffect(() => {
     const { current }: CustomElement<any> = ref;
 
@@ -29,33 +40,32 @@ function DescriboCrateBuilder({crate, profile, onDataChange}: any) {
     );
   }, [ref]);
 
-  // @ts-ignore
-  globalThis.globalFunctionFromReact = (arg) => {
-    return `globalThis.globalFunctionFromReact called with arg: '${arg}'`
-  }
-
-  class SomeClass {
-    name = "This a name from react"
-    age = 99
-
-    nameAndAge() {
-      return `${this.name} + ${this.age}`
+  // Update globalThis.DescriboCrateBuilderConfiguration
+  useEffect(() => {
+    console.log("useEffect", crate, profile)
+    const newConfig = {
+      crate, profile, lookup: {}
     }
-  }
-
-  // @ts-ignore
-  globalThis.globalObjectFromReact = new SomeClass()
-
+    setDescriboConfig(newConfig)
+    // @ts-ignore
+    globalThis.DescriboCrateBuilderConfiguration = newConfig
+  }, [crate, profile])
 
   return(
     <>
     <describo-crate-builder
       ref={ref}
-      crate={JSON.stringify(crate)}
-      profile={JSON.stringify({})}
-      someGlobalFunction={"globalFunctionFromReact"}
-      someGlobalObject={"globalObjectFromReact"}
+      config={"DescriboCrateBuilderConfiguration"}
     />
+      <div className="flex flex-col bg-purple-200 p-10 mt-10">
+      Contents of globalThis.DescriboCrateBuilderConfiguration in React:
+        <div>
+        {
+          // @ts-ignore
+          JSON.stringify(globalThis.DescriboCrateBuilderConfiguration)
+        }
+        </div>
+      </div>
     </>
   )
 }
@@ -70,12 +80,20 @@ function App() {
     setData({crate, profile})
   }
 
+  console.log("data", data)
   return (
     <div className="flex">
+      <div>
       <DescriboCrateBuilder
-        crate={metaData}
+        crate={data.crate}
+        profile={data.profile}
         onDataChange={onDataChange}
       />
+        <div>
+          {/*// @ts-ignore*/}
+          <button className="bg-blue-500" onClick={() => setData({crate:{"@context":"Updated crate"}, profile:{name:"Updated profile"}})}>Change crate</button>
+        </div>
+      </div>
       <div className="w-1/2 bg-green-200">
         <div className="border-b-2 border-gray-700">
           <h1 className="m-2 text-2xl">Preview Crate</h1>


### PR DESCRIPTION
1. Removed import of `style.css` in react [App.tsx](wc-test-app-react%2Fsrc%2FApp.tsx) as it is not required.

3. Instead of accessing `globalThis.DescriboCrateBuilderConfiguration` in [Shell.component.wc.vue](src%2Fcrate-builder%2FShell.component.wc.vue) I suggest to pass the name of the config object on `globalThis` via the `config` prop. This way we could theoretically have multiple components on screen with different configs, and it is the responsibility of the caller to avoid name clashes.

4. The React side is now reactive: when you press the "Change crate" button the value of the crate field changes in `globalThis[props.config]`. However, this change is not picked up in [Shell.component.wc.vue](src%2Fcrate-builder%2FShell.component.wc.vue). Can you please take a look at this? 
